### PR TITLE
Fixes for :crypto usage with OTP 24

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/simple_secrets.ex
+++ b/lib/simple_secrets.ex
@@ -11,9 +11,9 @@ defmodule SimpleSecrets do
     |> Base.decode16!()
     |> init()
   end
+
   def init(key) when bit_size(key) == @key_size do
-    %Sender{master: key,
-            key_id: Primatives.identify(key)}
+    %Sender{master: key, key_id: Primatives.identify(key)}
   end
 
   def pack(data, sender) do
@@ -53,7 +53,7 @@ defmodule SimpleSecrets do
   end
 
   defp body_to_data(data) do
-    <<_ :: binary-size(16), bindata :: binary>> = data
+    <<_::binary-size(16), bindata::binary>> = data
     Primatives.deserialize(bindata)
   end
 
@@ -64,7 +64,7 @@ defmodule SimpleSecrets do
 
   defp decrypt_body(cipher_data, master) do
     key = Primatives.derive_sender_key(master)
-    <<iv :: binary-size(16), encrypted :: binary>> = cipher_data
+    <<iv::binary-size(16), encrypted::binary>> = cipher_data
     Primatives.decrypt(encrypted, key, iv)
   end
 
@@ -76,7 +76,7 @@ defmodule SimpleSecrets do
   end
 
   defp verify(packet, master, key_id) do
-    <<packet_key_id :: binary-size(6), _ :: binary>> = packet
+    <<packet_key_id::binary-size(6), _::binary>> = packet
 
     if !Primatives.equals?(packet_key_id, key_id) do
       raise SimpleSecrets.Exception, code: :key_mismatch
@@ -92,7 +92,7 @@ defmodule SimpleSecrets do
       raise SimpleSecrets.Exception, code: :mac_mismatch
     end
 
-    <<_ :: binary-size(6), body :: binary>> = data
+    <<_::binary-size(6), body::binary>> = data
     body
   end
 end

--- a/lib/simple_secrets/primatives.ex
+++ b/lib/simple_secrets/primatives.ex
@@ -88,6 +88,7 @@ defmodule SimpleSecrets.Primatives do
     case buffer |> byte_size |> rem(4) do
       0 ->
         buffer
+
       diff ->
         pad(buffer, 4 - diff)
     end

--- a/lib/simple_secrets/primatives.ex
+++ b/lib/simple_secrets/primatives.ex
@@ -58,7 +58,7 @@ defmodule SimpleSecrets.Primatives do
   for n <- 1..32 do
     def equals?(a, b) when byte_size(a) == unquote(n) and byte_size(b) == unquote(n) do
       :crypto.exor(a, b) ==
-        unquote(Stream.repeatedly(fn -> 0 end) |> Enum.take(n) |> :erlang.iolist_to_binary())
+        unquote(Stream.repeatedly(fn -> 0 end) |> Enum.take(n) |> IO.iodata_to_binary())
     end
   end
 
@@ -77,7 +77,7 @@ defmodule SimpleSecrets.Primatives do
   def serialize(object) do
     object
     |> Msgpax.pack!()
-    |> :erlang.iolist_to_binary()
+    |> IO.iodata_to_binary()
   end
 
   def deserialize(binary) do

--- a/lib/simple_secrets/primatives.ex
+++ b/lib/simple_secrets/primatives.ex
@@ -1,4 +1,8 @@
 defmodule SimpleSecrets.Primatives do
+  @moduledoc false
+
+  @cipher :aes_256_cbc
+
   def nonce() do
     :crypto.strong_rand_bytes(16)
   end
@@ -25,18 +29,19 @@ defmodule SimpleSecrets.Primatives do
 
   def encrypt(buffer, key) do
     iv = nonce()
-    cipher = :crypto.block_encrypt(:aes_cbc256, key, iv, PKCS7.pad(buffer))
+    cipher = :crypto.crypto_one_time(@cipher, key, iv, PKCS7.pad(buffer), true)
+
     iv <> cipher
   end
 
   def decrypt(buffer, key, iv) do
-    :crypto.block_decrypt(:aes_cbc256, key, iv, buffer)
+    :crypto.crypto_one_time(@cipher, key, iv, buffer, false)
     |> PKCS7.unpad()
   end
 
   def identify(buffer) do
     input = [buffer_size(buffer), buffer]
-    <<prefix :: binary-size(6), _ :: binary>> = :crypto.hash(:sha256, input)
+    <<prefix::binary-size(6), _::binary>> = :crypto.hash(:sha256, input)
     prefix
   end
 
@@ -47,12 +52,13 @@ defmodule SimpleSecrets.Primatives do
   end
 
   def mac(buffer, hmac_key) do
-    :crypto.hmac(:sha256, hmac_key, buffer)
+    :crypto.mac(:hmac, :sha256, hmac_key, buffer)
   end
 
   for n <- 1..32 do
     def equals?(a, b) when byte_size(a) == unquote(n) and byte_size(b) == unquote(n) do
-      :crypto.exor(a, b) == unquote(Stream.repeatedly(fn -> 0 end) |> Enum.take(n) |> :erlang.iolist_to_binary)
+      :crypto.exor(a, b) ==
+        unquote(Stream.repeatedly(fn -> 0 end) |> Enum.take(n) |> :erlang.iolist_to_binary())
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule SimpleSecretsEx.Mixfile do
     [
       app: :simple_secrets,
       description: "A simple, opinionated library for encrypting small packets of data securely.",
-      version: "1.0.2",
+      version: "1.1.0",
       elixir: "~> 1.2",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule SimpleSecretsEx.Mixfile do
 
   defp deps do
     [
-      {:msgpax, "~> 2.2.0"},
+      {:msgpax, "~> 2.2"},
       {:pkcs7, "~> 1.0.2"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -2,29 +2,37 @@ defmodule SimpleSecretsEx.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :simple_secrets,
-     description: "A simple, opinionated library for encrypting small packets of data securely.",
-     version: "1.0.2",
-     elixir: "~> 1.2",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     package: package(),
-     deps: deps()]
+    [
+      app: :simple_secrets,
+      description: "A simple, opinionated library for encrypting small packets of data securely.",
+      version: "1.0.2",
+      elixir: "~> 1.2",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      package: package(),
+      deps: deps()
+    ]
   end
 
   def application do
-    [applications: [:logger]]
+    [
+      extra_applications: [:logger, :crypto]
+    ]
   end
 
   defp deps do
-    [ {:msgpax, "~> 2.2.0"},
-      {:pkcs7, "~> 1.0.2"} ]
+    [
+      {:msgpax, "~> 2.2.0"},
+      {:pkcs7, "~> 1.0.2"}
+    ]
   end
 
   defp package do
-    [files: ["lib", "mix.exs", "README*"],
-     maintainers: ["Cameron Bytheway"],
-     licenses: ["MIT"],
-     links: %{"GitHub" => "https://github.com/camshaft/simple_secrets_ex"}]
+    [
+      files: ["lib", "mix.exs", "README*"],
+      maintainers: ["Cameron Bytheway"],
+      licenses: ["MIT"],
+      links: %{"GitHub" => "https://github.com/camshaft/simple_secrets_ex"}
+    ]
   end
 end


### PR DESCRIPTION
Updates calls to `:crypto.block_decrypt/4` and `:crypto.hmac/3` to use the new `:crypto` API. Additionally added a `mix format` configuration and updated calls to `:erlang.iolist_to_binary/1` to the Elixir [`IO.iodata_to_binary/1`](https://github.com/elixir-lang/elixir/blob/v1.13.2/lib/elixir/lib/io.ex#L665). 

For more information see the [Erlang changes to crypto for OTP 24](https://erlang.org/documentation/doc-12.0/doc/general_info/removed.html#old-crypto-api).